### PR TITLE
AA-226 Support 2-bundler (p2p tests) 

### DIFF
--- a/bundlers/skandha/.env
+++ b/bundlers/skandha/.env
@@ -1,3 +1,3 @@
 #This is be the ENR exposed by they "boot" node, manually copied here to be fed into the peer node.
 #TODO: sanity-check that the boot node indeed exposes this one..
-ENR="enr:-KS4QH08nQLcfXFFvdf7duuLrzvusFZMnDtfLPIwNzX7h55WP5fEZ_cZ1wGHsOY-FICoI0q2p0MTV7v-wnAlDRJGDEkFgmlkgnY0gmlwhKweAAOPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"
+BOOT_ENR="enr:-KS4QCykFaCh9x2UqeXDi--tY6Pb3J5Q2v0jLxIMS5Y7dzYfLUNhW5qsg2dqzC99vzthJiiY-94You404-m3PdWl8WEFgmlkgnY0gmlwhMCoEGWPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"

--- a/bundlers/skandha/.env
+++ b/bundlers/skandha/.env
@@ -1,3 +1,3 @@
 #This is be the ENR exposed by they "boot" node, manually copied here to be fed into the peer node.
 #TODO: sanity-check that the boot node indeed exposes this one..
-BOOT_ENR="enr:-KS4QCykFaCh9x2UqeXDi--tY6Pb3J5Q2v0jLxIMS5Y7dzYfLUNhW5qsg2dqzC99vzthJiiY-94You404-m3PdWl8WEFgmlkgnY0gmlwhMCoEGWPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"
+BOOT_ENR="enr:-KS4QKKtZ64yNl2JqCmOAe6owCLe6CFuPZYVR2Na5-ymtoBHc3ce3Np6RU5ObROx73t-O4MiK01Lt6T9zlbFeHstA-AFgmlkgnY0gmlwhMCoZGWPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"

--- a/bundlers/skandha/.env
+++ b/bundlers/skandha/.env
@@ -1,3 +1,3 @@
 #This is be the ENR exposed by they "boot" node, manually copied here to be fed into the peer node.
 #TODO: sanity-check that the boot node indeed exposes this one..
-ENR="enr:-KS4QLQXcPMJYK2jrVgC9P9u5ObCbTyrntDidD7vQ8F3tXK4G1gRrpUeS79KpENduMHD8UVaWAtiK0sc8dXI9wFU9S0FgmlkgnY0gmlwhH8AAAGPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"
+ENR="enr:-KS4QH08nQLcfXFFvdf7duuLrzvusFZMnDtfLPIwNzX7h55WP5fEZ_cZ1wGHsOY-FICoI0q2p0MTV7v-wnAlDRJGDEkFgmlkgnY0gmlwhKweAAOPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"

--- a/bundlers/skandha/.env
+++ b/bundlers/skandha/.env
@@ -1,0 +1,3 @@
+#This is be the ENR exposed by they "boot" node, manually copied here to be fed into the peer node.
+#TODO: sanity-check that the boot node indeed exposes this one..
+ENR="enr:-KS4QLQXcPMJYK2jrVgC9P9u5ObCbTyrntDidD7vQ8F3tXK4G1gRrpUeS79KpENduMHD8UVaWAtiK0sc8dXI9wFU9S0FgmlkgnY0gmlwhH8AAAGPbWVtcG9vbF9zdWJuZXRziAAAAAAAAAAAiXNlY3AyNTZrMaEDXy5_rNLasQOQHoH6ONKx7dt9MX7IV9RlUqiZ7o-vG-yDdGNwghDxg3VkcIIQ8Q"

--- a/bundlers/skandha/bootDataDir/peer-id.json
+++ b/bundlers/skandha/bootDataDir/peer-id.json
@@ -1,0 +1,5 @@
+{
+  "id": "16Uiu2HAmK4YCszGhF5eLPfPBBAbULdvWxgiFtqo6cmujLffLjWZR",
+  "pubKey": "CAISIQNfLn+s0tqxA5Aegfo40rHt230xfshX1GVSqJnuj68b7A==",
+  "privKey": "CAISINU2K8Ay8Vhz2MQeAvG2KQexFVktCwgrqRewm0VMdeWw"
+}

--- a/bundlers/skandha/p2p-boot.yml
+++ b/bundlers/skandha/p2p-boot.yml
@@ -1,14 +1,20 @@
 # start a standlone bundler for testing.
 # bring up a the bundler with its own geth instance
 
+#TODO: we assume that the boot bundler exposes BOOT_ENR 
+# need to EITHER receive ENR as parameter, or validate we generate exactly the same one.
 services:
 
   bundler:
     ports: [ '3000:3000' ]
     image: etherspot/skandha
     command: node --testingMode --api.port 3000
-      --p2p.enrHost 172.30.0.3
+      --p2p.enrHost $BUNDLER_IP
       --redirectRpc --executor.bundlingMode manual 
+    networks:
+      default:
+      p2p:
+        ipv4_address: $BUNDLER_IP
     volumes:
       - ./bootDataDir/peer-id.json:/root/.skandha/db/peer-id.json
     environment:
@@ -17,8 +23,12 @@ services:
       - SKANDHA_DEV_RELAYER=test test test test test test test test test test test junk
       - SKANDHA_DEV_BENEFICIARY=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
-  #TODO: this IP depends on docker-compose structure. 
-  #exposed with: 
-  # docker exec -ti bundler-1 /bin/sh -c "ip -o -4 address"
-  # docker exec -ti bundler-1 /bin/sh -c "cat /etc/hosts"
-  # docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' bundler-1
+
+  bundler-verify:
+    image: docker
+    # volumes:
+    #   - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      bundler:
+        condition: service_started
+    command: echo docker exec runbundler-bundler-1 cat /root/.skandha/db/enr

--- a/bundlers/skandha/p2p-boot.yml
+++ b/bundlers/skandha/p2p-boot.yml
@@ -1,0 +1,17 @@
+# start a standlone bundler for testing.
+# bring up a the bundler with its own geth instance
+
+services:
+
+  bundler:
+    ports: [ '3000:3000' ]
+    image: etherspot/skandha
+    command: node --testingMode --api.port 3000
+      --redirectRpc --executor.bundlingMode manual 
+    volumes:
+      - ./bootDataDir/peer-id.json:/root/.skandha/db/peer-id.json
+    environment:
+      - SKANDHA_DEV_RPC=$ETH_RPC_URL
+      - SKANDHA_DEV_ENTRYPOINTS=${ENTRYPOINT}
+      - SKANDHA_DEV_RELAYER=test test test test test test test test test test test junk
+      - SKANDHA_DEV_BENEFICIARY=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/bundlers/skandha/p2p-boot.yml
+++ b/bundlers/skandha/p2p-boot.yml
@@ -7,6 +7,7 @@ services:
     ports: [ '3000:3000' ]
     image: etherspot/skandha
     command: node --testingMode --api.port 3000
+      --p2p.enrHost 172.30.0.3
       --redirectRpc --executor.bundlingMode manual 
     volumes:
       - ./bootDataDir/peer-id.json:/root/.skandha/db/peer-id.json
@@ -15,3 +16,9 @@ services:
       - SKANDHA_DEV_ENTRYPOINTS=${ENTRYPOINT}
       - SKANDHA_DEV_RELAYER=test test test test test test test test test test test junk
       - SKANDHA_DEV_BENEFICIARY=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
+  #TODO: this IP depends on docker-compose structure. 
+  #exposed with: 
+  # docker exec -ti bundler-1 /bin/sh -c "ip -o -4 address"
+  # docker exec -ti bundler-1 /bin/sh -c "cat /etc/hosts"
+  # docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' bundler-1

--- a/bundlers/skandha/p2p-peer.yml
+++ b/bundlers/skandha/p2p-peer.yml
@@ -1,0 +1,16 @@
+# start a standlone bundler for testing.
+# bring up a the bundler with its own geth instance
+
+services:
+
+  bundler:
+    ports: [ "3001:3000" ]
+    image: etherspot/skandha
+    command: node --testingMode --api.port 3000
+      --redirectRpc --executor.bundlingMode manual 
+      --p2p.bootEnrs $ENR
+    environment:
+      - SKANDHA_DEV_RPC=$ETH_RPC_URL
+      - SKANDHA_DEV_ENTRYPOINTS=${ENTRYPOINT}
+      - SKANDHA_DEV_RELAYER=junk junk junk junk junk junk junk junk junk junk junk test
+      - SKANDHA_DEV_BENEFICIARY=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/bundlers/skandha/p2p-peer.yml
+++ b/bundlers/skandha/p2p-peer.yml
@@ -8,10 +8,15 @@ services:
     image: etherspot/skandha
     command: node --testingMode --api.port 3000
       --redirectRpc --executor.bundlingMode manual 
-      --p2p.enrHost 172.30.0.4
-      --p2p.bootEnrs $ENR
+      --p2p.enrHost $BUNDLER2_IP
+      --p2p.bootEnrs $BOOT_ENR
+    networks:
+      default:
+      p2p:
+        ipv4_address: $BUNDLER2_IP
     environment:
       - SKANDHA_DEV_RPC=$ETH_RPC_URL
       - SKANDHA_DEV_ENTRYPOINTS=${ENTRYPOINT}
       - SKANDHA_DEV_RELAYER=junk junk junk junk junk junk junk junk junk junk junk test
       - SKANDHA_DEV_BENEFICIARY=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+

--- a/bundlers/skandha/p2p-peer.yml
+++ b/bundlers/skandha/p2p-peer.yml
@@ -8,6 +8,7 @@ services:
     image: etherspot/skandha
     command: node --testingMode --api.port 3000
       --redirectRpc --executor.bundlingMode manual 
+      --p2p.enrHost 172.30.0.4
       --p2p.bootEnrs $ENR
     environment:
       - SKANDHA_DEV_RPC=$ETH_RPC_URL

--- a/empty.yml
+++ b/empty.yml
@@ -1,0 +1,4 @@
+#first "docker-compose" file referenced by "runbundler"
+#Used to make sure all paths are relative to project root,
+#regardless from where the "real" docker-compose is loaded.
+version: '3'

--- a/runall.sh
+++ b/runall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash  -x
 root=`realpath \`dirname $0\``
 
 BUILD=$root/build
@@ -31,7 +31,7 @@ echo ====================================================================
 echo ====== $bundlerTitle
 echo ====================================================================
 
-basename=`basename -s .yml $bundler`
+basename=`basename -s .env \`basename -s .yml $bundler\``
 outxml=$OUT/$basename.xml
 outjson=$OUT/$basename.json
 outraw=$OUT/$basename.txt

--- a/runall.sh
+++ b/runall.sh
@@ -5,7 +5,10 @@ BUILD=$root/build
 OUT=$BUILD/out
 test -d bundler-spec-tests || git clone https://github.com/eth-infinitism/bundler-spec-tests.git
 
-BUNDLERS="`pwd`/bundlers/*/*yml"
+#by default, run all single-bundler configs
+BUNDLERS=`ls $root/bundlers/*/*yml|grep -v p2p`
+
+#if parameter is given, use it as single-bundler yml, or as testenv file
 if [ -n "$1" -a -r "$1" ]; then
 BUNDLERS=`realpath $1`
 shift

--- a/runall.sh
+++ b/runall.sh
@@ -49,11 +49,6 @@ function getEnv {
   echo ${val:-$def}
 }
 
-case "$bundler" in
-  *yml) PYTEST_FOLDER=`getEnv $root/runbundler/runbundler.env PYTEST_FOLDER tests/one` ;;
-  *env) PYTEST_FOLDER=`getEnv $bundler PYTEST_FOLDER tests/p2p` ;;
-esac
-
 #todo: better name to extract the name from the yml file?
 #from actual image, can do docker inspect {imageid} | jq .Config.Env
 name=`sed -ne 's/ *NAME=[ "]*\([^"]*\)"*/\1/p' $bundler`
@@ -64,7 +59,7 @@ echo "Running bundler $bundler, name=$name" > $outraw
 if $root/runbundler/runbundler.sh $bundler start; then
 
   case "$bunder" in
-    *yml) PYTEST_FOLDER=`getEnv $root/runbundler/runbundler.env PYTEST_FOLDER tests/one` ;;
+    *yml) PYTEST_FOLDER=`getEnv $root/runbundler/runbundler.env PYTEST_FOLDER tests/single` ;;
     *env) PYTEST_FOLDER=`getEnv $bundler PYTEST_FOLDER tests/p2p` ;;
   esac
 

--- a/runbundler/geth.yml
+++ b/runbundler/geth.yml
@@ -4,7 +4,7 @@ services:
     container_name: geth-1.10
     ports: [ '8545:8545' ]
     image: ethereum/client-go:release-1.10
-    command: --verbosity 2
+    command: --verbosity 1
       --http.vhosts '*,localhost,host.docker.internal'
       --http
       --http.api personal,eth,net,web3,debug

--- a/runbundler/run2bundlers.env
+++ b/runbundler/run2bundlers.env
@@ -1,0 +1,23 @@
+#note: this is the global env, read by the docker-compose.yml file.
+# each service in the docker-compose must forward 
+# needed environment vars to its own environment
+
+#urls are based on service names (defined in the docker-compose)
+ETH_RPC_URL=http://eth-node:8545
+#BUNDLER_URL=http://bundler:3000/rpc
+BUNDLER_URL=http://bundler:3000/rpc
+BUNDLER2_URL=http://bundler2:3000/rpc
+ETH_NODE_YML=geth.yml
+
+ENTRYPOINT=0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+
+#extra addresses (or private keys) to fund
+FUND="0xc6cbc5ffad570fdad0544d1b5358a36edeb98d163b6567912ac4754e144d4edb 
+	0x43378ff8C70109Ee4Dbe85aF34428ab0615EBd23
+	0x49Aa4e8210822CCd50b966944D415e5b4667AE3E
+	0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+#expect env vars: BUNDLER_BOOT_YML, BUNDLER_PEER_YML
+
+#enable "bash -x" on scripts
+VERBOSE=

--- a/runbundler/run2bundlers.env
+++ b/runbundler/run2bundlers.env
@@ -9,6 +9,13 @@ BUNDLER_URL=http://bundler:3000/rpc
 BUNDLER2_URL=http://bundler2:3000/rpc
 ETH_NODE_YML=geth.yml
 
+# run2bundlers.yml define the "p2p_network" to include these IPs
+#bootnode bundler must use this IP. 
+BUNDLER_IP=192.168.16.101
+#peer bundler must use this IP
+BUNDLER2_IP=192.168.16.102
+
+
 ENTRYPOINT=0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 
 #extra addresses (or private keys) to fund

--- a/runbundler/run2bundlers.env
+++ b/runbundler/run2bundlers.env
@@ -4,17 +4,21 @@
 
 #urls are based on service names (defined in the docker-compose)
 ETH_RPC_URL=http://eth-node:8545
-#BUNDLER_URL=http://bundler:3000/rpc
+ETH_NODE_YML=runbundler/geth.yml
+
+#bootnode bundler must expose itself as this url
 BUNDLER_URL=http://bundler:3000/rpc
+
+#2nd bundler (peer) must expose itself as:
 BUNDLER2_URL=http://bundler2:3000/rpc
-ETH_NODE_YML=geth.yml
 
-# run2bundlers.yml define the "p2p_network" to include these IPs
+# subnet to contain the static IPs of bundlers:
+P2P_SUBNET=192.168.100.0/24
+
 #bootnode bundler must use this IP. 
-BUNDLER_IP=192.168.16.101
+BUNDLER_IP=192.168.100.101
 #peer bundler must use this IP
-BUNDLER2_IP=192.168.16.102
-
+BUNDLER2_IP=192.168.100.102
 
 ENTRYPOINT=0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 
@@ -23,8 +27,6 @@ FUND="0xc6cbc5ffad570fdad0544d1b5358a36edeb98d163b6567912ac4754e144d4edb
 	0x43378ff8C70109Ee4Dbe85aF34428ab0615EBd23
 	0x49Aa4e8210822CCd50b966944D415e5b4667AE3E
 	0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-
-#expect env vars: BUNDLER_BOOT_YML, BUNDLER_PEER_YML
 
 #enable "bash -x" on scripts
 VERBOSE=

--- a/runbundler/run2bundlers.sh
+++ b/runbundler/run2bundlers.sh
@@ -22,7 +22,7 @@ shift
 shift
 case "$cmd" in 
 
-	start) $DC run --rm wait-for-bundler ;;
+	start) $DC run --rm wait-all ;;
         down) $DC down -t 1 ;;
 	stop) $DC stop -t 1 ;;
 	#execute misc docker-compose command

--- a/runbundler/run2bundlers.sh
+++ b/runbundler/run2bundlers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -xe
+dir=`dirname $0`
+
+if [ -z "$2" ] ; then
+       echo usage: "$0 {bootyml} {start|stop|..}"
+       exit 1 
+fi
+
+DC="docker-compose --env-file $dir/run2bundlers.env -f $dir/run2bundlers.yml"
+
+export BUNDLER_YML=`realpath $1`
+export BUNDLER2_YML=`realpath $2`
+ENVFILE=`dirname $BUNDLER_YML`/.env
+if [ -r $ENVFILE ] ; then
+	export `grep -v '#' $ENVFILE`
+fi
+#env for bundler2 ?
+
+cmd=$3
+shift
+shift
+shift
+case "$cmd" in 
+
+	start) $DC run --rm wait-for-bundler ;;
+        down) $DC down -t 1 ;;
+	stop) $DC stop -t 1 ;;
+	#execute misc docker-compose command
+	*) $DC $cmd $* ;;
+
+esac
+

--- a/runbundler/run2bundlers.sh
+++ b/runbundler/run2bundlers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 dir=`dirname $0`
 
 if [ -z "$2" ] ; then

--- a/runbundler/run2bundlers.yml
+++ b/runbundler/run2bundlers.yml
@@ -71,7 +71,7 @@ services:
         condition: service_started
     restart: on-failure:5
 
-  wait-for-bundler:
+  wait-all:
     image: ghcr.io/foundry-rs/foundry:latest
     command: echo started
     depends_on:
@@ -97,6 +97,6 @@ networks:
   #     - ENTRYPOINT=$ENTRYPOINT
   #     - BUNDLER_URL=$BUNDLER_URL
   #   depends_on:
-  #     wait-for-bundler:
+  #     wait-all:
   #       condition: service_completed_successfully
 

--- a/runbundler/run2bundlers.yml
+++ b/runbundler/run2bundlers.yml
@@ -40,6 +40,11 @@ services:
       deployer:
         condition: service_completed_successfully
 
+  bundler-verify:
+    extends:
+      file: $BUNDLER_YML
+      service: bundler-verify
+
   bundler2: 
     extends:
       file: $BUNDLER2_YML
@@ -74,6 +79,13 @@ services:
         condition: service_completed_successfully
       bundler-waiter2:
         condition: service_completed_successfully
+
+networks:
+  #the network where BUNDLER_IP and BUNDLER2_IP reside
+  p2p:
+    ipam:
+      config:
+        - subnet: "192.168.16.0/24"
 
   #todo: incomplete..
   # runtest:

--- a/runbundler/run2bundlers.yml
+++ b/runbundler/run2bundlers.yml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   funder:
-    build: ./funder
+    build: ./runbundler/funder
     environment:
       - FUND=$FUND 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
       - ETH_RPC_URL=$ETH_RPC_URL
@@ -85,7 +85,7 @@ networks:
   p2p:
     ipam:
       config:
-        - subnet: "192.168.16.0/24"
+        - subnet: "$P2P_SUBNET"
 
   #todo: incomplete..
   # runtest:

--- a/runbundler/run2bundlers.yml
+++ b/runbundler/run2bundlers.yml
@@ -1,0 +1,90 @@
+# docker-compose to bring up a single bundler, with all needed services
+version: '3'
+
+services:
+
+  funder:
+    build: ./funder
+    environment:
+      - FUND=$FUND 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+      - ETH_RPC_URL=$ETH_RPC_URL
+      - ENTRYPOINT=$ENTRYPOINT
+      - VERBOSE=$VERBOSE
+    restart: on-failure:3
+    depends_on:
+      eth-node:
+        condition: service_started
+
+  deployer:
+    image: accountabstraction/deployer:0.6
+    # build: ./deployer
+    environment:
+      - ETH_RPC_URL=$ETH_RPC_URL
+      - ENTRYPOINT=$ENTRYPOINT
+      - VERBOSE=$VERBOSE
+    depends_on:
+      funder:
+        condition: service_completed_successfully
+
+  #launch shared node.
+  eth-node:
+    extends:
+      file: $ETH_NODE_YML
+      service: eth-node 
+
+  bundler: 
+    extends:
+      file: $BUNDLER_YML
+      service: bundler
+    depends_on:
+      deployer:
+        condition: service_completed_successfully
+
+  bundler2: 
+    extends:
+      file: $BUNDLER2_YML
+      service: bundler
+    depends_on:
+      bundler-waiter:
+        condition: service_completed_successfully
+
+  bundler-waiter:
+    image: ghcr.io/foundry-rs/foundry:latest
+    command: 
+      - "sleep 1; cast rpc eth_chainId -r $BUNDLER_URL"
+    depends_on:
+      bundler:
+        condition: service_started
+    restart: on-failure:5
+
+  bundler-waiter2:
+    image: ghcr.io/foundry-rs/foundry:latest
+    command: 
+      - "sleep 1; cast rpc eth_chainId -r $BUNDLER2_URL"
+    depends_on:
+      bundler2:
+        condition: service_started
+    restart: on-failure:5
+
+  wait-for-bundler:
+    image: ghcr.io/foundry-rs/foundry:latest
+    command: echo started
+    depends_on:
+      bundler-waiter:
+        condition: service_completed_successfully
+      bundler-waiter2:
+        condition: service_completed_successfully
+
+  #todo: incomplete..
+  # runtest:
+  #   build: ./runtest
+  #   #    command: $RUNTEST
+  #   environment:
+  #     - TEST=pdm run pytest --tb=short -rA -W ignore::DeprecationWarning --url $BUNDLER_URL --entry-point $ENTRYPOINT --ethereum-node $ETH_RPC_URL
+  #     - ETH_RPC_URL=$ETH_RPC_URL
+  #     - ENTRYPOINT=$ENTRYPOINT
+  #     - BUNDLER_URL=$BUNDLER_URL
+  #   depends_on:
+  #     wait-for-bundler:
+  #       condition: service_completed_successfully
+

--- a/runbundler/runbundler.env
+++ b/runbundler/runbundler.env
@@ -4,9 +4,10 @@
 
 #urls are based on service names (defined in the docker-compose)
 ETH_RPC_URL=http://eth-node:8545
-#BUNDLER_URL=http://bundler:3000/rpc
+ETH_NODE_YML=runbundler/geth.yml
+
+#bundler must expose itself as this url:
 BUNDLER_URL=http://bundler:3000/rpc
-ETH_NODE_YML=geth.yml
 
 ENTRYPOINT=0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -8,7 +8,7 @@ usage: $0 {ymlfile|testfile} {start|stop|..}
   ymlfile -  a single bundler yml file. uses DCFILE="runbundler.yml"
   testfile - env file to define all launch env. params.
   cmd:
-  	start (wait for wait-for-bundler task to exit)
+  	start (wait for wait-all task to complete)
   	any docker-compose command (e.g: up,start,down,logs)
   testfile expected env.vars:
     DCFILE - the docker-compose.yml file to use. defaults to run2bundlers.yml
@@ -51,7 +51,7 @@ DC="docker-compose $DCPARAMS -f $root/empty.yml -f $DCFILE"
 cmd=$cmd
 case "$cmd" in 
 
-	start) $DC run --rm wait-for-bundler ;;
+	start) $DC run --rm wait-all ;;
 	down) $DC down -t 1 ;;
 	stop) $DC stop -t 1 ;;
 	#execute misc docker-compose command

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -1,25 +1,57 @@
-#!/bin/bash
+#!/bin/bash  -x
 dir=`dirname $0`
 
-if [ -z "$2" ] ; then
-       echo usage: "$0 {ymlfile} {start|stop|..}"
-       exit 1 
-fi
+function usage() {
+cat <<EOF
+usage: $0 {ymlfile|testfile} {start|stop|..}
+  ymlfile -  a single bundler yml file. uses DCFILE="runbundler.yml"
+  testfile - env file to define all launch env. params.
+  cmd:
+  	start (wait for wait-for-bundler task to exit)
+  	any docker-compose command (e.g: up,start,down,logs)
+  testfile expected env.vars:
+    DCFILE - the docker-compose.yml file to use. defaults to run2bundlers.yml
+    BUNDLER_YML - bundler-specific file for bootnode bundler
+    BUNDLER2_YML - bundler-specific file for peer bundler
+	ENVFILE, ENVFILE2 - extra env.vars used by above bundlers
+EOF
+exit 1 
 
-DC="docker-compose -f $dir/runbundler.yml"
-export BUNDLER_YML=`realpath $1`
-ENVFILE=`dirname $BUNDLER_YML`/.env
-if [ -r $ENVFILE ] ; then
-	export `grep -v '#' $ENVFILE`
-fi
+}
 
+file=$1
 cmd=$2
 shift
 shift
+
+test -z "$cmd" && usage
+
+case "$file" in 
+	*.yml)
+		export DCFILE="$dir/runbundler.yml"
+		export DCPARAMS="--env-file $dir/runbundler.env"
+		ENVFILE=`dirname $BUNDLER_YML`/.env
+		test -r $ENVFILE && DCPARAMS="$DCPARAMS --env-file $ENVFILE"
+		export BUNDLER_YML=$file
+		;;
+
+	*.env)
+		export DCFILE="$dir/run2bundlers.yml"
+		export DCPARAMS="--env-file $dir/run2bundlers.env"
+		source $file
+		test -r "$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $ENVFILE"
+		test -r "$ENVFILE2" && DCPARAMS="$DCPARAMS --env-file $ENVFILE2"
+		;;
+	*)	usage ;;
+
+esac
+
+DC="docker-compose $DCPARAMS -f $dir/../empty.yml -f $DCFILE"
+cmd=$cmd
 case "$cmd" in 
 
 	start) $DC run --rm wait-for-bundler ;;
-        down) $DC down -t 1 ;;
+	down) $DC down -t 1 ;;
 	stop) $DC stop -t 1 ;;
 	#execute misc docker-compose command
 	*) $DC $cmd $* ;;

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -1,5 +1,6 @@
-#!/bin/bash  -x
+#!/bin/bash 
 dir=`dirname $0`
+root=`cd $dir/.. ; pwd`
 
 function usage() {
 cat <<EOF
@@ -19,7 +20,7 @@ exit 1
 
 }
 
-file=$1
+file=`realpath $1`
 cmd=$2
 shift
 shift
@@ -31,7 +32,7 @@ case "$file" in
 		export DCFILE="$dir/runbundler.yml"
 		export DCPARAMS="--env-file $dir/runbundler.env"
 		ENVFILE=`dirname $BUNDLER_YML`/.env
-		test -r $ENVFILE && DCPARAMS="$DCPARAMS --env-file $ENVFILE"
+		test -r "$root/$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $root/$ENVFILE"
 		export BUNDLER_YML=$file
 		;;
 
@@ -39,14 +40,14 @@ case "$file" in
 		export DCFILE="$dir/run2bundlers.yml"
 		export DCPARAMS="--env-file $dir/run2bundlers.env"
 		source $file
-		test -r "$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $ENVFILE"
-		test -r "$ENVFILE2" && DCPARAMS="$DCPARAMS --env-file $ENVFILE2"
+		test -n "$ENVFILE" && test -r "$root/$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $root/$ENVFILE"
+		test -n "$ENVFILE2" && test -r "$root/$ENVFILE2" && DCPARAMS="$DCPARAMS --env-file $root/$ENVFILE2"
 		;;
 	*)	usage ;;
 
 esac
 
-DC="docker-compose $DCPARAMS -f $dir/../empty.yml -f $DCFILE"
+DC="docker-compose $DCPARAMS -f $root/empty.yml -f $DCFILE"
 cmd=$cmd
 case "$cmd" in 
 

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -31,8 +31,9 @@ case "$file" in
 	*.yml)
 		export DCFILE="$dir/runbundler.yml"
 		export DCPARAMS="--env-file $dir/runbundler.env"
-		ENVFILE=`dirname $BUNDLER_YML`/.env
-		test -r "$root/$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $root/$ENVFILE"
+		envfile1=`dirname $file`/.env
+		ENVFILE=`cd $root; realpath $envfile1 2> /dev/null`
+		test -r "$ENVFILE" && DCPARAMS="$DCPARAMS --env-file $ENVFILE"
 		export BUNDLER_YML=$file
 		;;
 

--- a/runbundler/runbundler.yml
+++ b/runbundler/runbundler.yml
@@ -49,7 +49,7 @@ services:
         condition: service_started
     restart: on-failure:5
 
-  wait-for-bundler:
+  wait-all:
     image: ghcr.io/foundry-rs/foundry:latest
     command: echo started
     depends_on:
@@ -66,6 +66,6 @@ services:
   #     - ENTRYPOINT=$ENTRYPOINT
   #     - BUNDLER_URL=$BUNDLER_URL
   #   depends_on:
-  #     wait-for-bundler:
+  #     wait-all:
   #       condition: service_completed_successfully
 

--- a/runbundler/runbundler.yml
+++ b/runbundler/runbundler.yml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   funder:
-    build: ./funder
+    build: ./runbundler/funder
     environment:
       - FUND=$FUND 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
       - ETH_RPC_URL=$ETH_RPC_URL

--- a/tests/skandha-skandha.env
+++ b/tests/skandha-skandha.env
@@ -1,0 +1,6 @@
+export BUNDLER_YML=bundlers/skandha/p2p-boot.yml
+export BUNDLER2_YML=bundlers/skandha/p2p-peer.yml
+
+#the skanha env file defines the BOOT_ENR that is exposed by p2p-boot.
+# the peer should use this enr to connect to
+export ENVFILE=bundlers/skandha/.env


### PR DESCRIPTION
- there are now 2 modes for running tests:
- running for bundlers: 
    - `./runall.sh bundlers/aabundler/aabundler.yml`
    - (runs all tests in `tests/single`)
- running "test environment", 
    - `./runall.sh tests/skandha-skandha.env`
    - (runs all tests in `tests/p2p`)

(note that this requires the "run2bundlers" branch on the test repo)