### PR TITLE
Fix docker startup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ on:
         description: 'skip test - check github update'
         required: false
         type: boolean
+
+      ignore_cache:
+        description: 'ignore cache'
+        required: false
+        type: boolean
 #  push: 
 #    branches:
 #      - '*'
@@ -69,6 +74,7 @@ jobs:
 
       # restore cache of bundler-spec-tests, and its submodules
       - uses: actions/cache@v3
+        if: ${{ ! inputs.ignore_cache }}
         with:
           path: bundler-spec-tests
           key: ${{ runner.os }}-${{ hashFiles('bundler-spec-tests/pdm.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ ! inputs.ignore_cache }}
         with:
           path: bundler-spec-tests
-          key: ${{ runner.os }}-${{ hashFiles('bundler-spec-tests/pdm.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('bundler-spec-tests/pdm.lock', 'bundler-spec-tests/@account-abstraction/contracts/**/*.sol') }}
 
       - run: cd bundler-spec-tests; git checkout
         name: "re-checkout bundler-spec-tests (on top of cache)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /bundler-spec-tests/
 /out-results/
+.DS_Store

--- a/runall.sh
+++ b/runall.sh
@@ -58,8 +58,10 @@ name=`sed -ne 's/ *NAME=[ "]*\([^"]*\)"*/\1/p' $bundler`
 
 test -z $name && name=$basename
 
-echo "Running bundler $bundler, name=$name" > $outraw
+echo "`date`: starting bundler $bundler, name=$name" | tee -a $outraw
 if $root/runbundler/runbundler.sh $bundler pull-start; then
+
+  echo "`date`: started bundler $bundler, name=$name" | tee -a $outraw
 
   case "$bunder" in
     *yml) PYTEST_FOLDER=`getEnv $root/runbundler/runbundler.env PYTEST_FOLDER tests/single` ;;
@@ -76,6 +78,8 @@ if $root/runbundler/runbundler.sh $bundler pull-start; then
   test -r $outxml && xq . $outxml > $outjson
 
 fi
+
+echo "`date`: done bundler $bundler, name=$name" | tee -a $outraw
 
 $root/runbundler/runbundler.sh $bundler logs -t > $outlogs
 $root/runbundler/runbundler.sh $bundler down

--- a/runall.sh
+++ b/runall.sh
@@ -59,7 +59,7 @@ name=`sed -ne 's/ *NAME=[ "]*\([^"]*\)"*/\1/p' $bundler`
 test -z $name && name=$basename
 
 echo "Running bundler $bundler, name=$name" > $outraw
-if $root/runbundler/runbundler.sh $bundler start; then
+if $root/runbundler/runbundler.sh $bundler pull-start; then
 
   case "$bunder" in
     *yml) PYTEST_FOLDER=`getEnv $root/runbundler/runbundler.env PYTEST_FOLDER tests/single` ;;

--- a/runbundler/run2bundlers.yml
+++ b/runbundler/run2bundlers.yml
@@ -60,7 +60,7 @@ services:
     depends_on:
       bundler:
         condition: service_started
-    restart: on-failure:5
+    restart: on-failure:10
 
   bundler-waiter2:
     image: ghcr.io/foundry-rs/foundry:latest
@@ -69,7 +69,7 @@ services:
     depends_on:
       bundler2:
         condition: service_started
-    restart: on-failure:5
+    restart: on-failure:10
 
   wait-all:
     image: ghcr.io/foundry-rs/foundry:latest

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -65,6 +65,7 @@ cmd=$cmd
 case "$cmd" in 
 
 	start) $DC run --rm wait-all ;;
+	pull-start) $DC pull && $DC run --rm wait-all ;; 
 	down) $DC down -t 1 ;;
 	stop) $DC stop -t 1 ;;
 	#execute misc docker-compose command

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -65,7 +65,7 @@ cmd=$cmd
 case "$cmd" in 
 
 	start) $DC run --rm wait-all ;;
-	pull-start) $DC pull && $DC run --rm wait-all ;; 
+	pull-start) $DC pull --quiet && $DC config|grep image && $DC run --rm wait-all ;; 
 	down) $DC down -t 1 ;;
 	stop) $DC stop -t 1 ;;
 	#execute misc docker-compose command

--- a/runbundler/runbundler.yml
+++ b/runbundler/runbundler.yml
@@ -43,16 +43,19 @@ services:
   bundler-waiter:
     image: ghcr.io/foundry-rs/foundry:latest
     command: 
-      - "sleep 1; cast rpc eth_chainId -r $BUNDLER_URL"
+      - "sleep 2; cast rpc eth_chainId -r $BUNDLER_URL"
     depends_on:
-      bundler:
-        condition: service_started
+      #not depending on bundler: if bundler process aborts, this "waiter" would hang forever..
+      deployer:
+        condition: service_completed_successfully
     restart: on-failure:10
 
   wait-all:
     image: ghcr.io/foundry-rs/foundry:latest
     command: echo started
     depends_on:
+      bundler:
+        condition: service_started
       bundler-waiter:
         condition: service_completed_successfully
 

--- a/runbundler/runbundler.yml
+++ b/runbundler/runbundler.yml
@@ -43,11 +43,11 @@ services:
   bundler-waiter:
     image: ghcr.io/foundry-rs/foundry:latest
     command: 
-      - "cast rpc eth_chainId -r $BUNDLER_URL"
+      - "sleep 1; cast rpc eth_chainId -r $BUNDLER_URL"
     depends_on:
       bundler:
         condition: service_started
-    restart: on-failure:5
+    restart: on-failure:10
 
   wait-all:
     image: ghcr.io/foundry-rs/foundry:latest


### PR DESCRIPTION
- pull-start - perform docker-compose "pull" before doing "start"
   (default for "runall)
- bundler-waiter: wait longer (10 seconds, with delays) for bundler to  start.
- prevent "wait forever" if bundler fails to start.
