### PR TITLE
chore: use transeptorlabs/bundler:0.5.3-alpha.0 image for ep v06

### DIFF
--- a/bundlers/transeptor/transeptor.yml
+++ b/bundlers/transeptor/transeptor.yml
@@ -1,13 +1,13 @@
 services:
   bundler:
-    image: transeptorlabs/bundler:latest
+    image: transeptorlabs/bundler:0.5.3-alpha.0
     ports: [ '3000:3000' ]
     environment:
-      - TRANSEPTOR_MNEMONIC=test test test test test test test test test test test junk
-      - TRANSEPTOR_ENTRYPOINT_ADDRESS=$ENTRYPOINT
-      - TRANSEPTOR_BENEFICIARY=0xd21934eD8eAf27a67f0A70042Af50A1D6d195E81
+      - MNEMONIC=test test test test test test test test test test test junk
+      - BENEFICIARY=0xd21934eD8eAf27a67f0A70042Af50A1D6d195E81
     command: >
       --network $ETH_RPC_URL
       --port 3000
       --txMode base
       --httpApi web3,eth,debug
+      --entryPoint $ENTRYPOINT


### PR DESCRIPTION
Use `transeptorlabs/bundler:0.5.3-alpha.0` image for ep v06