### PR TITLE
AA-472 support geth-native-tracer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       # - run: test -d bundler-spec-tests || git clone --recurse-submodules --depth 1 https://github.com/eth-infinitism/bundler-spec-tests -b v07
       #  name: clone bundler-spec-tests
 
-      - run: ( curl -L https://foundry.paradigm.xyz | bash ; source /home/runner/.bashrc; foundryup )
+      - run: ( curl -L https://foundry.paradigm.xyz | sh ; sh -c foundryup )
         name: Install foundry (for rip7560 contracts)
 
       - run: git submodule status --recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,13 @@ jobs:
       - run: cd bundler-spec-tests; git checkout
         name: "re-checkout bundler-spec-tests (on top of cache)"
 
+      - name: checked-out source artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sourceTree
+          path: .
+          retention-days: 30
+
         #for faster "update-deps" for spec
       - run: yarn --cwd bundler-spec-tests/spec remove gatsby || echo "already removed"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,18 +65,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          show-progress: false
-
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: eth-infinitism/bundler-spec-tests
-      #     path: bundler-spec-tests
-      #     submodules: true
+#          show-progress: false
 
       # - run: test -d bundler-spec-tests || git clone --recurse-submodules --depth 1 https://github.com/eth-infinitism/bundler-spec-tests -b v07
       #  name: clone bundler-spec-tests
 
-      - run: cd bundler-spec-tests && (git describe --tags; git submodule ) | tee .git.status
+      - run: git submodule status --recursive
         name: check bundler-spec-tests and submodules status
 
       # restore cache of bundler-spec-tests, and its submodules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
 
       - run: curl -L https://foundry.paradigm.xyz | bash ; ~/.config/.foundry/bin/foundryup
         name: Install foundry (for rip7560 contracts)
-      - run: export PATH=$PATH:~/.config/.foundry/bin
+      - run: mv ~/.config/.foundry/bin/* ~/.local/bin
       - run: forge version || echo no forge found
 
       - run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,10 @@ jobs:
 
     steps:
 
-      - run: ( curl -L https://foundry.paradigm.xyz | bash ; find ~ | grep foundr ; bash -c foundryup )
+      - run: curl -L https://foundry.paradigm.xyz | bash ; ~/.config/.foundry/bin/foundryup
         name: Install foundry (for rip7560 contracts)
+      - run: export PATH=$PATH:~/.config/.foundry/bin
+      - run: forge version || echo no forge found
 
       - run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,8 @@ jobs:
       # - run: test -d bundler-spec-tests || git clone --recurse-submodules --depth 1 https://github.com/eth-infinitism/bundler-spec-tests -b v07
       #  name: clone bundler-spec-tests
 
-      - run: |
-		curl -L https://foundry.paradigm.xyz | bash
-		source /home/runner/.bashrc
-		foundryup
+      - run: ( curl -L https://foundry.paradigm.xyz | bash ; source /home/runner/.bashrc; foundryup )
+        name: Install foundry (for rip7560 contracts)
 
       - run: git submodule status --recursive
         name: check bundler-spec-tests and submodules status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,11 @@ jobs:
       # - run: test -d bundler-spec-tests || git clone --recurse-submodules --depth 1 https://github.com/eth-infinitism/bundler-spec-tests -b v07
       #  name: clone bundler-spec-tests
 
+      - run: |
+		curl -L https://foundry.paradigm.xyz | bash
+		source /home/runner/.bashrc
+		foundryup
+
       - run: git submodule status --recursive
         name: check bundler-spec-tests and submodules status
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,15 +57,15 @@ jobs:
 
     steps:
 
+      - run: pip install jq yq
+      - run: which xq
+
       - run: curl -L https://foundry.paradigm.xyz | bash ; ~/.config/.foundry/bin/foundryup
         name: Install foundry (for rip7560 contracts)
-      - run: mv ~/.config/.foundry/bin/* ~/.local/bin
+      - run: mv ~/.config/.foundry/bin/* `dirname \`which xq\` `
       - run: forge version || echo no forge found
 
       - run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
-
-      - run: pip install jq yq
-      - run: which xq
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
 
     steps:
 
+      - run: ( curl -L https://foundry.paradigm.xyz | bash ; find ~ | grep foundr ; bash -c foundryup )
+        name: Install foundry (for rip7560 contracts)
+
       - run: curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
 
       - run: pip install jq yq
@@ -69,9 +72,6 @@ jobs:
 
       # - run: test -d bundler-spec-tests || git clone --recurse-submodules --depth 1 https://github.com/eth-infinitism/bundler-spec-tests -b v07
       #  name: clone bundler-spec-tests
-
-      - run: ( curl -L https://foundry.paradigm.xyz | sh ; sh -c foundryup )
-        name: Install foundry (for rip7560 contracts)
 
       - run: git submodule status --recursive
         name: check bundler-spec-tests and submodules status

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,3 @@
 	path = bundler-spec-tests
 	url = https://github.com/eth-infinitism/bundler-spec-tests.git
 	branch = v07
-[submodule "bundler-spec-tests/"]
-	branch = v07

--- a/bundlers/aabundler/aabundler.yml
+++ b/bundlers/aabundler/aabundler.yml
@@ -1,10 +1,11 @@
 
 services:
   bundler:
-    image: accountabstraction/bundler:0.7.0
+    image: accountabstraction/bundler:0.7.1
     environment:
-      NAME: aa-ref-bundler-0.7.0
-    command: --network $ETH_RPC_URL
+      NAME: aa-ref-bundler-0.7.1
+    command: --network $ETH_RPC_URL  --tracerRpcUrl $NODE_NATIVE_TRACER_URL
+
     ports: [ '3000:3000' ]
     volumes:
       - ./workdir:/app/workdir:ro

--- a/runbundler/geth-native-tracer.yml
+++ b/runbundler/geth-native-tracer.yml
@@ -1,0 +1,19 @@
+services:
+  # geth node, compiled with bundlerCollectorTracer as native tracer
+  node-native-tracer:
+    container_name: geth-native-tracer
+    image: dtr22/geth4337
+    command: --verbosity 1
+      --http.vhosts '*,localhost,host.docker.internal'
+      --http
+      --http.port 8888
+      --http.api eth,net,web3,debug
+      --http.corsdomain '*'
+      --http.addr "0.0.0.0"
+      --networkid 1337
+      --dev
+      --dev.period 0
+      --allow-insecure-unlock
+      --rpc.allow-unprotected-txs
+      --dev.gaslimit 20000000
+

--- a/runbundler/geth-native-tracer.yml
+++ b/runbundler/geth-native-tracer.yml
@@ -2,7 +2,7 @@ services:
   # geth node, compiled with bundlerCollectorTracer as native tracer
   node-native-tracer:
     container_name: geth-native-tracer
-    image: dtr22/geth4337
+    image: accountabstraction/geth-native-tracer
     command: --verbosity 1
       --http.vhosts '*,localhost,host.docker.internal'
       --http

--- a/runbundler/runbundler.env
+++ b/runbundler/runbundler.env
@@ -6,6 +6,9 @@
 ETH_RPC_URL=http://eth-node:8545
 ETH_NODE_YML=runbundler/geth.yml
 
+NODE_NATIVE_TRACER_URL=http://node-native-tracer:8888
+NODE_NATIVE_TRACER_YML=runbundler/geth-native-tracer.yml
+
 #bundler must expose itself as this url:
 BUNDLER_URL=http://bundler:3000/rpc
 

--- a/runbundler/runbundler.sh
+++ b/runbundler/runbundler.sh
@@ -60,7 +60,7 @@ case "$file" in
 
 esac
 
-DC="docker-compose $DCPARAMS -f $root/empty.yml -f $DCFILE"
+DC="docker compose $DCPARAMS -f $root/empty.yml -f $DCFILE"
 cmd=$cmd
 case "$cmd" in 
 

--- a/runbundler/runbundler.yml
+++ b/runbundler/runbundler.yml
@@ -32,6 +32,11 @@ services:
       file: $ETH_NODE_YML
       service: eth-node 
 
+  node-native-tracer:
+    extends: 
+      file: $NODE_NATIVE_TRACER_YML
+      service: node-native-tracer
+
   bundler: 
     extends:
       file: $BUNDLER_YML
@@ -39,7 +44,9 @@ services:
     depends_on:
       deployer:
         condition: service_completed_successfully
-
+      node-native-tracer:
+          condition: service_started
+  
   bundler-waiter:
     image: ghcr.io/foundry-rs/foundry:latest
     command: 


### PR DESCRIPTION
- runall now brings up an geth instance that supports **bundlerCollectorTracer**
- bundlers are not required to use it, but if they do:
- the new node is exposed as `$NODE_NATIVE_TRACER_URL`
- the aabundler is a new version that use this node with `--tracerRpcUrl` parameter (see bundler PR https://github.com/eth-infinitism/bundler/pull/230)